### PR TITLE
Show Engine Logo + Name if possible, prior to Info display

### DIFF
--- a/src/components/EngineCard.tsx
+++ b/src/components/EngineCard.tsx
@@ -52,16 +52,16 @@ export function EngineCard({
       ];
 
   return (
-    <div className={`engineComponent ${loading ? "loading" : ""}`}>
+    <div className={`engineComponent ${!engine ? "loading" : ""}`}>
       <div className="engineInfoHeader">
-        {loading ? (
+        {!engine ? (
           <SkeletonBlock width={36} height={36} style={{margin: 6}} />
         ) : (
           <EngineLogo engine={engine!} />
         )}
 
         <div className="engineName">
-          {loading ? (placeholder ?? "Loading…") : engine!.name}
+          {!engine ? (placeholder ?? "Loading…") : engine!.name}
         </div>
 
         <div className="engineEval">


### PR DESCRIPTION
On a new game starting, the EngineCard for Black could have the logo + name immediately, even though no engine info has been presented yet. Observed locally as a game finished, and confirmed that this works.

Applies to White as well, when Lc0 is playing, since initial updates are slow.