### PR TITLE
Bypass 50ms updateBoard() rate limit, when getting the final result

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,9 +138,9 @@ function App() {
     }
   }
 
-  function updateBoard() {
+  function updateBoard(bypass_rate_limit = false) {
     const currentTime = new Date().getTime();
-    if (currentTime - lastBoardUpdateRef.current <= 50) return;
+    if (!bypass_rate_limit && currentTime - lastBoardUpdateRef.current <= 50) return;
 
     const gameAtTurn = getGameAtMoveNumber(
       game.current,
@@ -311,6 +311,7 @@ function App() {
       case "result":
         game.current.setHeader("Termination", msg.reason);
         game.current.setHeader("Result", msg.score);
+        updateBoard(true);
     }
   }
 


### PR DESCRIPTION
When mate gets blitzed quickly, the moves come faster than 50ms; and the `newMove` message's updateBoard() call might bail-out early; and then when a `result` message comes in, we produce the overlay on a non-updated board. I meant to screenshot an example, but I've not yet. 

This can occur in more than just mates, ofc. But that is the easiest case to observe. I've seen it with draws by Syzygy as well.

At least, this is my understanding. I am learning how React works.