### PR TITLE
add reducedMotion prop to eval graph

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,7 @@ function App() {
   const [kibitzerSettings, setKibitzerSettings] = useState<EngineSettings>(
     getDefaultKibitzerSettings()
   );
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   const currentMoveNumber = useRef(-1);
   const liveInfosRef = useRef<LiveEngineData>({
@@ -514,6 +515,7 @@ function App() {
             liveInfosBlue={liveInfosRef.current.blue.liveInfo}
             setCurrentMoveNumber={setCurrentMoveNumber}
             currentMoveNumber={currentMoveNumber.current}
+            reducedMotion={prefersReducedMotion}
           />
         ) : (
           <>

--- a/src/components/GameGraph.tsx
+++ b/src/components/GameGraph.tsx
@@ -14,6 +14,7 @@ type GameGraphProps = {
   liveInfosBlue: LiveInfoEntry[];
   setCurrentMoveNumber: (callback: (previous: number) => number) => void;
   currentMoveNumber: number;
+  reducedMotion: boolean;
 };
 
 const COLORS = {
@@ -101,6 +102,7 @@ export function GameGraph({
   liveInfosBlue,
   setCurrentMoveNumber,
   currentMoveNumber,
+  reducedMotion,
 }: GameGraphProps) {
   const liveInfos = {
     white: liveInfosWhite,
@@ -158,6 +160,7 @@ export function GameGraph({
             responsive: true,
             maintainAspectRatio: false,
             elements: { line: { tension: 0 } },
+            animation: { duration: reducedMotion ? 0 : undefined /* default */ },
             animations: {
               y: {
                 from: (ctx: any) => {


### PR DESCRIPTION
The graph animations pose an accessibility issue for some folks. In a later PR I will also add a setting for this to the settings menu (hopefully we can extend it beyond kibitzer settings?) that defaults basde on the media query

## Testing

Graph should animate as normal. Then follow the instructions at https://stackoverflow.com/a/59709067/13458117 to turn on "reduced motion" on your computer, **refresh**, and check that the graph no longer animates between stages.