### PR TITLE
add TypeScript types to MoveRow, and fix usage of callback to go to a move

### DIFF
--- a/src/components/MoveList.tsx
+++ b/src/components/MoveList.tsx
@@ -277,6 +277,19 @@ const MoveList = memo(
   }
 );
 
+type MoveRowProps = {
+  moveIndex: number;
+  moveNumber: number;
+  whiteMove: string;
+  blackMove: string;
+  whiteActive: boolean;
+  blackActive: boolean;
+  rowActive: boolean;
+  disagreementWhite: boolean;
+  disagreementBlack: boolean;
+  setCurrentMoveNumber: (callback: (n: number) => number) => void;
+}
+
 const MoveRow = memo(
   ({
     moveIndex,
@@ -289,18 +302,18 @@ const MoveRow = memo(
     disagreementWhite,
     disagreementBlack,
     setCurrentMoveNumber,
-  }: any) => {
+  }: MoveRowProps) => {
     return (
       <tr>
         <th
           className={"move right" + (rowActive ? " currentMove" : "")}
-          onClick={() => setCurrentMoveNumber(moveIndex + 1)}
+          onClick={() => setCurrentMoveNumber(() => moveIndex + 1)}
         >
           {moveNumber}.
         </th>
         <td
           className={moveClass(whiteActive, disagreementWhite)}
-          onClick={() => setCurrentMoveNumber(moveIndex + 1)}
+          onClick={() => setCurrentMoveNumber(() => moveIndex + 1)}
         >
           {whiteMove}
         </td>
@@ -308,7 +321,7 @@ const MoveRow = memo(
           {blackMove && (
             <span
               className={moveClass(blackActive, disagreementBlack)}
-              onClick={() => setCurrentMoveNumber(moveIndex + 2)}
+              onClick={() => setCurrentMoveNumber(() => moveIndex + 2)}
             >
               {blackMove}
             </span>


### PR DESCRIPTION
Add types to our props instead of `any` 🥴 

Then fix the usage of the callback, which restores the ability to click on a move to bring the board to that position.

### Testing

Code review only, but you can also test that clicking a move works again.