### PR TITLE
use en dashes for displaying the game outcome

### DIFF
--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -16,6 +16,10 @@ function formatDuration(value: number) {
   return `in ${(value / 60).toFixed(0)} hours`;
 }
 
+function formatOutcome(outcome: string) {
+    return outcome.replace(/-/, "\u2013"); // en dash
+}
+
 const Schedule = memo(
   ({ engines, event, selectedGame, requestEvent }: ScheduleProps) => {
     const scheduleRef = useRef<HTMLDivElement>(null);
@@ -140,7 +144,7 @@ const Schedule = memo(
             const vsText = isCurrentGame
               ? "vs."
               : game.outcome
-                ? `${game.outcome}`
+                ? formatOutcome(game.outcome)
                 : formatDuration(averageDuration * (i - currentGameIdx));
 
             return (


### PR DESCRIPTION
Most style guides ([example](https://www.chicagomanualofstyle.org/qanda/data/faq/topics/HyphensEnDashesEmDashes/faq0165.html)) recommend en dashes for describing sports scores.

Before:
<img width="548" height="100" alt="image" src="https://github.com/user-attachments/assets/edda4e60-4b91-4f62-b454-55158adfe46d" />

After:
<img width="548" height="109" alt="image" src="https://github.com/user-attachments/assets/6fcd20d8-fbdb-43e2-b2fd-233dcbd57d19" />